### PR TITLE
Add Dockerfile for Linux integration tests

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,13 @@
+FROM circleci/python:3.7-stretch-node-browsers
+MAINTAINER Ryan Patrick Kyle "ryan@plotly.com"
+
+RUN sudo apt-get update \
+ && sudo wget -O - https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o microsoft.asc.gpg \
+ && sudo mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ \
+ && sudo wget https://packages.microsoft.com/config/debian/9/prod.list \
+ && sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list \
+ && sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg \
+ && sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list \
+ && sudo apt-get install -y apt-transport-https \
+ && sudo apt-get update \
+ && sudo apt-get install -y dotnet-sdk-3.1 

--- a/build/README.md
+++ b/build/README.md
@@ -1,10 +1,10 @@
 # plotly/plotly.net:ci
 
-#### This Dockerfile is currently used to support integration and unit tests in the [Dash.NET](https://github.com/plotly/Dash.NET) repository.
+#### This Dockerfile is currently used to support integration and unit tests in the [Dash.NET](https://github.com/plotly/Dash.NET) and [Plotly.NET](https://github.com/plotly/Plotly.NET) repositories.
 
 ## Usage
 
-This image is pulled from within Dash.NET's [config.yml](https://github.com/plotly/Dash.NET/blob/dev/.circleci/config.yml):
+This image is pulled from within the respective project's [config.yml](https://github.com/plotly/Plotly.NET/blob/dev/.circleci/config.yml) as follows:
 
 ```yaml
     docker:

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,16 @@
+# plotly/plotly.net:ci
+
+#### This Dockerfile is currently used to support integration and unit tests in the [Dash.NET](https://github.com/plotly/Dash.NET) repository.
+
+## Usage
+
+This image is pulled from within Dash.NET's [config.yml](https://github.com/plotly/Dash.NET/blob/dev/.circleci/config.yml):
+
+```yaml
+    docker:
+      - image: plotly/plotly.net:ci
+```
+
+## Publication details
+
+[plotly/plotly.net:ci](https://hub.docker.com/r/plotly/plotly.net/tags)


### PR DESCRIPTION
This PR proposes to create a `build` directory in which to store project-related Dockerfiles, including an initial Dockerfile fro Linux testing, as well as a brief README describing the contents.