### PR TITLE
Update Docker image to use .NET Core SDK v5.0.101

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,4 +10,4 @@ RUN sudo apt-get update \
  && sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list \
  && sudo apt-get install -y apt-transport-https \
  && sudo apt-get update \
- && sudo apt-get install -y dotnet-sdk-3.1 
+ && sudo apt-get install -y dotnet-sdk-5.0


### PR DESCRIPTION
This PR proposes to bump the .NET Core SDK version to v5.0.101 from v3.1. The image has already been pushed to Docker Hub (`plotly/plotly.net:ci`).