### PR TITLE
Update package to net5

### DIFF
--- a/dev/Dash.NET.Dev.fsproj
+++ b/dev/Dash.NET.Dev.fsproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <AssemblyName>Dash.NET.Dev.App</AssemblyName>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Giraffe" Version="4.1.*" />
-    <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
+    <PackageReference Include="Giraffe" Version="5.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dev/Program.fs
+++ b/dev/Program.fs
@@ -9,10 +9,8 @@ open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Giraffe
-open Giraffe.ModelBinding
 
 open Dash.NET
-open Plotly.NET
 
 //----------------------------------------------------------------------------------------------------
 //============================================== LAYOUT ==============================================

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.302",
+    "version": "5.0.101",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Dash.NET/Dash.NET.fsproj
+++ b/src/Dash.NET/Dash.NET.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -183,8 +183,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Giraffe" Version="4.1.0" />
-    <PackageReference Include="Plotly.NET" Version="2.0.0-alpha2" />
+    <PackageReference Include="Giraffe" Version="5.0.0" />
+    <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
+    <PackageReference Include="Plotly.NET" Version="2.0.0-preview.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Dash.NET/DashApp.fs
+++ b/src/Dash.NET/DashApp.fs
@@ -1,7 +1,7 @@
 ﻿namespace Dash.NET
 
 open Giraffe
-open GiraffeViewEngine
+open Giraffe.ViewEngine
 open Views
 open Plotly.NET
 open System 

--- a/src/Dash.NET/Views.fs
+++ b/src/Dash.NET/Views.fs
@@ -1,7 +1,7 @@
 ﻿namespace Dash.NET
 
 module Views =
-    open Giraffe.GiraffeViewEngine
+    open Giraffe.ViewEngine
     
     let createConfigScript (config:DashConfig) =
         let innerJson = Newtonsoft.Json.JsonConvert.SerializeObject config

--- a/tests/Dash.NET.Tests/Dash.NET.Tests.fsproj
+++ b/tests/Dash.NET.Tests/Dash.NET.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Giraffe 5 has breaking changes. 

1. The minimum supported version is net5.
2. Giraffe.ViewEngine has been split into a separate package.
3. Taskbuilder.fs is no longer required. Giraffe 5 uses Ply internally.

Update Plotly.net for net5 support.

For #12