### PR TITLE
Streamline usage, remove verbosity

### DIFF
--- a/src/Dash.NET/DashComponents/ComponentBase.fs
+++ b/src/Dash.NET/DashComponents/ComponentBase.fs
@@ -33,6 +33,7 @@ type DashComponentStyle() = inherit DynamicObj()
 
 type DashComponentProps() = inherit DynamicObj()
 
+[<AutoOpen>]
 module ComponentPropTypes = 
 
     type InputType =

--- a/src/Dash.NET/DashComponents/HTMLComponents/Html.fs
+++ b/src/Dash.NET/DashComponents/HTMLComponents/Html.fs
@@ -7,6 +7,7 @@ open Plotly.NET
 /// https://github.com/alfonsogarciacaro/Feliz.Engine
 /// and are available under the Dash.NET.Html module.
 
+[<AutoOpen>]
 module Css =
     type Style = StyleProperty of string * obj
 
@@ -14,6 +15,7 @@ module Css =
     let Css =
         Feliz.CssEngine(fun k v -> StyleProperty(k, v))
 
+[<AutoOpen>]
 module Html =
     open Css
 

--- a/src/Dash.NET/DashConfig.fs
+++ b/src/Dash.NET/DashConfig.fs
@@ -3,6 +3,10 @@
 open Newtonsoft.Json
 open Plotly.NET
 
+open System
+open Giraffe
+open Microsoft.Extensions.Logging
+
 type HotReloadSettings =
     {
         [<JsonProperty("intervall")>]
@@ -14,6 +18,7 @@ type HotReloadSettings =
 //todo: use standard casing and add serialization flags instead.
 type DashConfig =
     {
+        //Dash Specific
         [<JsonProperty("url_base_pathname")>]
         UrlBasePathname: string Option
         [<JsonProperty("requests_pathname_prefix")>]
@@ -30,6 +35,14 @@ type DashConfig =
         SuppressCallbackExceptions: bool
         [<JsonProperty("update_title")>]
         UpdateTitle: string
+
+        //Giraffe, Logging and ASP.NET specific
+        [<JsonIgnore()>]
+        HostName: string
+        [<JsonIgnore()>]
+        LogLevel: LogLevel
+        [<JsonIgnore()>]
+        ErrorHandler: Exception -> HttpHandler
     }
     static member create
         urlBasePathname
@@ -40,6 +53,10 @@ type DashConfig =
         showUndoRedo
         suppressCallbackExceptions
         updateTitle
+
+        hostName
+        logLevel
+        errorHandler
         =
         {
             UrlBasePathname = urlBasePathname
@@ -51,9 +68,24 @@ type DashConfig =
             SuppressCallbackExceptions = suppressCallbackExceptions
             UpdateTitle = updateTitle
         //hot_reload                  = {Intervall = 3000; MaxRetry = 8}
+
+            HostName = hostName
+            LogLevel = logLevel
+            ErrorHandler = errorHandler
         }
 
     static member initDefault() =
-        DashConfig.create None "/" false true true false false "Updating..."
+        DashConfig.create 
+            None 
+            "/" 
+            false 
+            true 
+            true 
+            false 
+            false 
+            "Updating..."
+            "localhost"
+            LogLevel.Debug
+            ((fun ex ->  ex.Message) >> text)
 
     static member initDefaultWith(initializer: DashConfig -> DashConfig) = DashConfig.initDefault () |> initializer

--- a/src/Dash.NET/Operators.fs
+++ b/src/Dash.NET/Operators.fs
@@ -1,5 +1,6 @@
 ﻿namespace Dash.NET
 
+[<AutoOpen>]
 module Operators =
 
     /// Shorthand for creation of a dependency (binding of the property of a component)


### PR DESCRIPTION
- Added simple abstraction for ASP.NET initialization
- Added AutoOpen to several common submodules
    - `Html`
    - `DCC`
    - `Operators`
    - `ComponentPropTypes`

Example of update:
```fsharp
open Dash.NET

let dslLayout = 
    Html.div [
        Attr.className "section"
        Attr.id "main-section"
        Attr.children [
            Html.div [
                Attr.children "Test"
            ]
            Input.input "test" [] []
        ]
    ]

[<EntryPoint>]
let main args =
    DashApp.initDefault()
    |> DashApp.withLayout dslLayout
    |> DashApp.appendCSSLinks [ 
        "main.css"
        "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.1/css/bulma.min.css"
    ]
    |> DashApp.run args
```

Old version of the exact same example:
```fsharp
open System
open System.IO
open Microsoft.AspNetCore.Builder
open Microsoft.AspNetCore.Cors.Infrastructure
open Microsoft.AspNetCore.Hosting
open Microsoft.Extensions.Hosting
open Microsoft.Extensions.Logging
open Microsoft.Extensions.DependencyInjection
open Giraffe
open Dash.NET
open Newtonsoft.Json
open Dash.NET.Html
open Dash.NET.DCC

let dslLayout = 
    Html.div [
        Attr.className "section"
        Attr.id "main-section" 
        Attr.children [
            Html.div [
                Attr.children "Test"
            ]
            Input.input "test" [] []
        ]
    ]

let myDashApp =
    DashApp.initDefault() 
    |> DashApp.withLayout dslLayout 
    |> DashApp.appendCSSLinks [ 
        "main.css"
        "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.1/css/bulma.min.css" 
    ]

let errorHandler (ex : Exception) (logger : ILogger) =
    logger.LogError(ex, "An unhandled exception has occurred while executing the request.")
    clearResponse >=> setStatusCode 500 >=> text ex.Message

let configureCors (builder : CorsPolicyBuilder) =
    builder.WithOrigins("http://localhost:8080")
           .AllowAnyMethod()
           .AllowAnyHeader()
           |> ignore

let configureApp (app : IApplicationBuilder) =
    let env = app.ApplicationServices.GetService<IWebHostEnvironment>()
    (match env.EnvironmentName with
    | "Development" -> app.UseDeveloperExceptionPage()
    | _ -> app.UseGiraffeErrorHandler(errorHandler))
        .UseHttpsRedirection()
        .UseCors(configureCors)
        .UseStaticFiles()
        .UseGiraffe(DashApp.toHttpHandler myDashApp)

let configureServices (services : IServiceCollection) =
    services.AddCors()    |> ignore
    services.AddGiraffe() |> ignore

let configureLogging (builder : ILoggingBuilder) =
    builder.AddFilter(fun l -> l.Equals LogLevel.Debug)
           .AddConsole()
           .AddDebug() |> ignore

[<EntryPoint>]
let main args =
    printfn "%s" (JsonConvert.SerializeObject dslLayout)

    let contentRoot = Reflection.Assembly.GetExecutingAssembly().Location |> Path.GetDirectoryName
    let webRoot     = Path.Combine(contentRoot, "WebRoot")
    Host.CreateDefaultBuilder(args)
        .ConfigureWebHostDefaults(
            fun webHostBuilder ->
                webHostBuilder
                    .UseContentRoot(contentRoot)
                    .UseWebRoot(webRoot)
                    .Configure(Action<IApplicationBuilder> configureApp)
                    .ConfigureServices(configureServices)
                    .ConfigureLogging(configureLogging)
                    |> ignore)
        .Build()
        .Run()

    0
```
