### PR TITLE
Fixes for examples

### DIFF
--- a/src/Dash.NET.Giraffe/DashApp.fs
+++ b/src/Dash.NET.Giraffe/DashApp.fs
@@ -18,13 +18,32 @@ open Dash.NET
 open Newtonsoft.Json
 
 //Giraffe, Logging and ASP.NET specific
-type DashGiraffeConfig = {
-  HostName: string
-  IpAddress: string
-  Port : int
-  LogLevel: LogLevel
-  ErrorHandler: Exception -> HttpHandler
-}
+type DashGiraffeConfig = 
+    {
+        HostName: string
+        LogLevel: LogLevel
+        IpAddress: string
+        Port : int
+        ErrorHandler: Exception -> HttpHandler
+    }
+
+    static member initDefault hostname = 
+        {
+            HostName = hostname
+            IpAddress = "127.0.0.1"
+            Port = "5001"
+            LogLevel = LogLevel.Information
+            ErrorHandler = ((fun ex ->  ex.Message) >> text)
+        }
+
+    static member initDebug hostname = 
+        {
+            HostName = hostname
+            IpAddress = "127.0.0.1"
+            Port = "5001"
+            LogLevel = LogLevel.Debug
+            ErrorHandler = ((fun ex ->  ex.Message) >> text)
+        }
 
 type DashApp =
     {

--- a/src/Dash.NET.Giraffe/DashApp.fs
+++ b/src/Dash.NET.Giraffe/DashApp.fs
@@ -30,8 +30,8 @@ type DashGiraffeConfig =
     static member initDefault hostname = 
         {
             HostName = hostname
-            IpAddress = "127.0.0.1"
-            Port = "5001"
+            IpAddress = hostname
+            Port = 5001
             LogLevel = LogLevel.Information
             ErrorHandler = ((fun ex ->  ex.Message) >> text)
         }
@@ -39,8 +39,8 @@ type DashGiraffeConfig =
     static member initDebug hostname = 
         {
             HostName = hostname
-            IpAddress = "127.0.0.1"
-            Port = "5001"
+            IpAddress = hostname
+            Port = 5001
             LogLevel = LogLevel.Debug
             ErrorHandler = ((fun ex ->  ex.Message) >> text)
         }

--- a/src/Dash.NET/Callback.fs
+++ b/src/Dash.NET/Callback.fs
@@ -373,7 +373,13 @@ type Callback<'Function>
                 |> Seq.map (fun (argument,targetType) -> 
                     //printfn "JsonType: %A;      ArgType:%A" argument.Type targetType
                     // it may be necessary to inspect the JToken when the input is an object/higher kinded type
-                    argument.ToObject(targetType))
+                    if not <| isNull argument then
+                        argument.ToObject(targetType)
+                    else
+                        //F# can handle a non-nullable type being null, it just might throw an exception if you try to use it
+                        //you can get around this with Nullable<...> 
+                        null
+                )
             else
                 failwithf "handler function arguments and targetTypes have different lenght: args:%i vs. types:%i" callbackHandlerFunctionRange.Length (Seq.length args)
 

--- a/src/Dash.NET/DashComponents/ComponentBase.fs
+++ b/src/Dash.NET/DashComponents/ComponentBase.fs
@@ -147,7 +147,7 @@ module ComponentPropTypes =
                 value:IConvertible,
                 ?Disabled:bool
             ) =
-                let dro = DropdownOption()
+                let dro = RadioItemsOption()
 
                 label   |> DynObj.setValue dro "label"
                 value   |> DynObj.setValue dro "value"
@@ -163,7 +163,7 @@ module ComponentPropTypes =
                 ?Primary     :string,
                 ?Background  :string
             ) =
-                let tc = DropdownOption()
+                let tc = TabColors()
 
                 Border    |> DynObj.setValueOpt tc "border"
                 Primary   |> DynObj.setValueOpt tc "primary"


### PR DESCRIPTION
A handful of fixes to support documentation examples

- Added defaults to giraffe config to cut down on `open`s in examples
- Allow null inputs during callbacks
- Fixed issue where the `init` of some component options were returning the wrong types